### PR TITLE
Fix generated VM names - Round 2

### DIFF
--- a/caasp-stack.yaml
+++ b/caasp-stack.yaml
@@ -312,7 +312,7 @@ resources:
       resource_def:
         type: OS::Nova::Server
         properties:
-          name: caasp-worker-%index%
+          name: { list_join: ['-', [{get_param: 'OS::stack_name'}, 'worker', '%index%']] }
           image: { get_param: image }
           key_name: { get_resource: keypair }
           flavor: { get_param: worker_flavor }


### PR DESCRIPTION
The first PR merged before I relaized I hadn't commited part of the change.
This fixes the worker names per the previous commit message details.