### PR TITLE
Add worker count to environment file

### DIFF
--- a/caasp-environment.yaml
+++ b/caasp-environment.yaml
@@ -4,6 +4,7 @@ parameters:
   admin_flavor: m1.large
   master_flavor: m1.large
   worker_flavor: m1.large
+  worker_count: 1
   external_net: ext-net
   internal_net_cidr: 172.24.0.0/24
   dns_nameserver: 172.24.0.2


### PR DESCRIPTION
The default worker count is 5 which is too resource intensive in most cases so
setting this in the environment file.