### PR TITLE
Add comment to make sure users don't have IP conflicts

### DIFF
--- a/caasp-environment.yaml
+++ b/caasp-environment.yaml
@@ -6,5 +6,10 @@ parameters:
   worker_flavor: m1.large
   worker_count: 1
   external_net: ext-net
-  internal_net_cidr: 172.24.0.0/24
-  dns_nameserver: 172.24.0.2
+  # Make sure you use a CIDR that doesn't conflict with the CaaSP IPs:
+  # https://github.com/kubic-project/salt/blob/master/pillar/params.sls#L51
+  # https://github.com/kubic-project/velum/blob/master/app/controllers/setup_controller.rb#L34
+  # If dns_nameserver is the same as CaaSPs dns_cluster_ip then the kube service
+  # hostnames won't be resolved.
+  internal_net_cidr: 172.28.0.0/24
+  dns_nameserver: 172.28.0.2

--- a/caasp-stack.yaml
+++ b/caasp-stack.yaml
@@ -37,11 +37,11 @@ parameters:
     default: floating
   internal_net_cidr:
     type: string
-    description: Private network range which servers get deployed
+    description: Private network range which servers get deployed. Make sure this doesn't conflict with the any IP addresses CaaSP uses (e.g. the dns_cluster_ip).
     default: 172.28.0.0/24
   dns_nameserver:
     type: string
-    description: Address of a dns nameserver reachable
+    description: Address of a dns nameserver reachable.
     default: 172.28.0.2
   admin_flavor:
     type: string


### PR DESCRIPTION
CaaSP is already using the IP '172.24.0.2' for kube dns by default (although it can be configured by the user to some other value while boostraping in Velum). We should avoid using the same default and make sure the user is aware of this danger when altering the value.