### PR TITLE
Add option to enable the CAP ports

### DIFF
--- a/caasp-stack.yaml
+++ b/caasp-stack.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2015-04-30
+heat_template_version: 2016-10-14
 
 description: Template to create a CaaSP cluster on OpenStack
 
@@ -8,6 +8,7 @@ parameter_groups:
     parameters:
       - image
       - root_password
+      - open_cap_ports_for
 
   - label: sizing
     description: Sizing Parameters
@@ -69,6 +70,35 @@ parameters:
     type: string
     description: Root Password for the VMs
     default: linux
+  open_cap_ports_for:
+    type: string
+    description: The nodes which should have the CAP ports open. The kube.external_ips you are planning to set in the scf-config-values.yaml should have these ports open.
+    default: "none"
+    constraints:
+      - allowed_values:
+        - all
+        - "none"
+        - masters
+        - workers
+
+conditions:
+  worker_cap_ports_open:
+    or:
+    - equals:
+      - get_param: open_cap_ports_for
+      - workers
+    - equals:
+      - get_param: open_cap_ports_for
+      - all
+
+  master_cap_ports_open:
+    or:
+    - equals:
+      - get_param: open_cap_ports_for
+      - masters
+    - equals:
+      - get_param: open_cap_ports_for
+      - all
 
 resources:
   keypair:
@@ -193,6 +223,37 @@ resources:
           port_range_min: 30000
           port_range_max: 32768
 
+  secgroup_cap_ports_on:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+        - protocol: tcp
+          port_range_min: 80
+          port_range_max: 80
+        - protocol: tcp
+          port_range_min: 443
+          port_range_max: 443
+        - protocol: tcp
+          port_range_min: 2222
+          port_range_max: 2222
+        - protocol: tcp
+          port_range_min: 2793
+          port_range_max: 2793
+        - protocol: tcp
+          port_range_min: 4443
+          port_range_max: 4443
+        - protocol: tcp
+          port_range_min: 8443
+          port_range_max: 8443
+        - protocol: tcp
+          port_range_min: 20000
+          port_range_max: 20010
+
+  secgroup_cap_ports_off:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules: []
+
   admin:
     type: OS::Nova::Server
     depends_on:
@@ -289,6 +350,7 @@ resources:
       security_groups:
         - { get_resource: secgroup_base }
         - { get_resource: secgroup_master }
+        - { get_resource: { if: ["master_cap_ports_open", "secgroup_cap_ports_on", "secgroup_cap_ports_off"] } }
 
   master_floating_ip:
     type: OS::Neutron::FloatingIP
@@ -321,6 +383,7 @@ resources:
           security_groups:
             - { get_resource: secgroup_base }
             - { get_resource: secgroup_worker }
+            - { get_resource: { if: ["worker_cap_ports_open", "secgroup_cap_ports_on", "secgroup_cap_ports_off"] } }
           user_data_format: RAW
           user_data:
             str_replace:


### PR DESCRIPTION
and let the user specify the nodes with open cap ports because we don't know
which IPs the user is going to use for kube.external_ips in the scf-config-values.yaml