### PR TITLE
SCRD-2811 Add a Loadbalancer for CaaSP Master nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ Master and Worker nodes:
 
 ### Preparation
 
-1. Download the latest SUSE CaaS Platform for OpenStack image (for example, SUSE-CaaS-Platform-2.0-OpenStack-Cloud.x86_64-1.0.0-GM.qcow2) from https://download.suse.com.
+1. Download the latest SUSE CaaS Platform for OpenStack image (for example, SUSE-CaaS-Platform-3.0-OpenStack-Cloud.x86_64-1.0.0-GM.qcow2)
+   from https://download.suse.com/Download?buildid=z7ezhywXXRc~
+
 2. Upload the image to Glance:
 
 ```
   $ openstack image create --public --disk-format qcow2 --container-format \
-    bare --file SUSE-CaaS-Platform-2.0-for-OpenStack-Cloud.x86_64-2.0.0-GM.qcow2 \
-    CaaSP-2
+    bare --file SUSE-CaaS-Platform-3.0-OpenStack-Cloud.x86_64-1.0.0-GM.qcow2 \
+    SUSE-CaaS-Platform-3.0-OpenStack-Cloud
 ```
 
 3. Install the caasp-openstack-heat-templates package on a machine with SUSE OpenStack Cloud repositories:
@@ -50,15 +52,148 @@ Master and Worker nodes:
 1. In OpenStack Horizon, go to Project › Stacks › Launch Stack.
 2. Select File from the Template Source drop-down box and upload the caasp-stack.yaml file.
 3. In the Launch Stack dialog, provide the required information (stack name, password, flavor size, external network of your environment, etc.).
-4. Click Launch to launch the stack. This creates all required resources for running SUSE CaaS Platform in an OpenStack environment. The stack creates one Admin Node, one Master Node, and server worker nodes as specified.
+4. Click Launch to launch the stack. This creates all required resources for running SUSE CaaS Platform in an OpenStack environment. The stack
+   creates one Admin Node, one Master Node, and server worker nodes as specified.
 
 ### INSTALL TEMPLATES FROM THE COMMAND LINE
+
+### Steps
 
 1. Specify the appropriate flavor and network settings in the caasp-environment.yaml file.
 2. Create a stack in Heat by passing the template, environment file, and parameters:
 ```
   $ openstack stack create -t caasp-stack.yaml -e caasp-environment.yaml \
-    --parameter image=CaaSP-2 caasp-stack
+    --parameter image=SUSE-CaaS-Platform-3.0-OpenStack-Cloud caasp-stack
+```
+
+### INSTALL TEMPLATES FROM COMMAND LINE (FOR MULTIPLE MASTER NODES)
+
+Note: This heat stack with load balancer and multiple master nodes can only be created from command line,
+since Horizon does not have support for nested heat templates yet.
+
+### Prerequisites
+
+You need a working load balancer in your Openstack Cloud deployment. There are two load balancer providers
+available, 'octavia' and 'haproxy'.
+
+To verify if load balancer with octavia provider or haproxy provider is working correctly in Openstack installation
+you can try and create load balancer manually and check if the provisioning_status changes to 'Active'
+e.g.
+
+```
+neutron lbaas-loadbalancer-create --name test-lb --provider octavia  <SUBNET_ID>
+OR
+neutron lbaas-loadbalancer-create --name test-lb --provider haproxy  <SUBNET_ID>
+
+neutron lbaas-loadbalancer-show <LOAD_BALANCER_ID>
+OR
+Openstack CLI:
+openstack loadbalancer show <LOAD_BALANCER_ID>
+```
+
+Note: Octavia is default load balancer provider in SUSE Openstack Cloud, but it needs a some prerequisites to be setup like, for example
+amphora image should be available in Glance. Please refer to documentation in "Installing with
+Cloud Lifecyle Manager" guide in Post Installation->Configuring Loadbalancer as a Service->Section 31.3
+[Setup of prerequisites](https://www.suse.com/documentation/suse-openstack-cloud-8/book_installation/data/sect1_51_chapter_book_installation.html)
+for instructions on how to setup prerequisites which includes steps on "Installing the Amphora Image", "Register the image", and also
+steps on "Setup network, subnet, router, security and IP's" to set up a test "lb_net1" network with "lb_subnet1" subnet.
+
+e.g.
+```
+openstack network create lb_net1
+openstack subnet create --name lb_subnet1 lb_net1 --subnet-range 172.29.0.0/24 \
+  --gateway 172.29.0.2
+openstack router create lb_router1
+openstack router add subnet lb_router1 lb_subnet1
+openstack router set lb_router1 --external-gateway ext-net
+openstack network list
+
+Please use ID of lb_subnet1 as <SUBNET_ID> in neutron lbaas-loadbalancer-create commands above
+```
+
+To clean up the environment after the test please delete loadbalancer, router subnet and network
+that were created for the test.
+
+```
+openstack loadbalancer delete test-lb
+openstack subnet delete lb_subnet1
+openstack router delete lb_router1
+openstack network delete lb_net1
+```
+
+### Steps
+
+1. Specify the appropriate flavor and network settings in caasp-multi-master-environment.yaml file.
+2. Set master_count to more desired number in caasp-multi-master-environment.yaml file
+e.g.
+
+```
+master_count: 3
+```
+Note: The master count has to be set to odd number of nodes  e.g. 1, 3, 5 and so on
+
+3. In a multi master deployment, load balancer is created which points to multiple master nodes for ports
+   32000 and 6443. By default the load balancer provider is 'haproxy'.
+   You can switch the load balancer provider to 'octavia' by changing the master_lb_provider in caasp-multi-master-environment.yaml file
+   e.g.
+
+```
+master_lb_provider: haproxy
+```
+   
+
+4. Create a stack in Heat by passing the template, environment file, and parameters:
+```
+  $ openstack stack create -t caasp-multi-master-stack.yaml -e caasp-multi-master-environment.yaml \
+    --parameter image=SUSE-CaaS-Platform-3.0-OpenStack-Cloud caasp-multi-master-stack
+```
+
+5. Floating IP address of the load balancer can be found using the
+   following steps
+
+```
+openstack loadbalancer list --provider
+
+OR
+
+neutron lbaas-loadbalancer-list
+neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
++--------------------------------------+------------------------------------+----------------------------------+-------------+---------------------+----------+
+| id                                   | name                               | tenant_id                        | vip_address | provisioning_status | provider |
++--------------------------------------+------------------------------------+----------------------------------+-------------+---------------------+----------+
+| 0d973d80-1c79-40a4-881b-42d111ee9625 | caasp-stack-master_lb-bhr66gtrx3ue | fd7ffc07400642b1b05dbef647deb4c1 | 172.28.0.6  | ACTIVE              | haproxy  |
++--------------------------------------+------------------------------------+----------------------------------+-------------+---------------------+----------+
+
+Openstack CLI:
+openstack loadbalancer show 0d973d80-1c79-40a4-881b-42d111ee9625
+OR
+neutron lbaas-loadbalancer-show 0d973d80-1c79-40a4-881b-42d111ee9625
+neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
++---------------------+------------------------------------------------+
+| Field               | Value                                          |
++---------------------+------------------------------------------------+
+| admin_state_up      | True                                           |
+| description         |                                                |
+| id                  | 0d973d80-1c79-40a4-881b-42d111ee9625           |
+| listeners           | {"id": "c9a34b63-a1c8-4a57-be22-75264769132d"} |
+|                     | {"id": "4fa2dae0-126b-4eb0-899f-b2b6f5aab461"} |
+| name                | caasp-stack-master_lb-bhr66gtrx3ue             |
+| operating_status    | ONLINE                                         |
+| pools               | {"id": "8c011309-150c-4252-bb04-6550920e0059"} |
+|                     | {"id": "c5f55af7-0a25-4dfa-a088-79e548041929"} |
+| provider            | haproxy                                        |
+| provisioning_status | ACTIVE                                         |
+| tenant_id           | fd7ffc07400642b1b05dbef647deb4c1               |
+| vip_address         | 172.28.0.6                                     |
+| vip_port_id         | 53ad27ba-1ae0-4cd7-b798-c96b53373e8b           |
+| vip_subnet_id       | 87d18a53-ad0c-4d71-b82a-050c229b710a           |
++---------------------+------------------------------------------------+
+
+Openstack CLI:
+openstack floating ip list | grep 172.28.0.6
+| d636f38b-3197-4b13-ad9a-276072481b0c | fd7ffc07400642b1b05dbef647deb4c1 | 172.28.0.6       | 10.84.65.37         | 53ad27ba-1ae0-4cd7-b798-c96b53373e8b |
+
+Load balancer floating ip address is 10.84.65.37
 ```
 
 ### ACCESSING VELUM SUSE CAAS PLATFORM DASHBOARD

--- a/caasp-master.yaml
+++ b/caasp-master.yaml
@@ -1,0 +1,125 @@
+heat_template_version: 2016-10-14
+description: Template to create a CaaSP master and add as master load balancer pool member
+
+parameters:
+  master_name:
+    type: string
+    description: Name of the master
+    default: caasp_master
+  master_flavor:
+    type: string
+    description: Flavor of the master
+    constraints:
+      - custom_constraint: nova.flavor
+  master_port_1:
+    type: string
+    description: Master API port 1
+  master_lb_pool_1:
+    type: string
+    description: Load balancer pool 1
+    constraints:
+      - custom_constraint: neutron.lbaas.pool
+  master_port_2:
+    type: string
+    description: Master port 2
+  master_lb_pool_2:
+    type: string
+    description: Load balancer pool 2
+    constraints:
+      - custom_constraint: neutron.lbaas.pool
+  admin_node_ip:
+    type: string
+    description: IP address of the admin node
+  keypair:
+    type: string
+    description: Nova key value pair
+    constraints:
+      - custom_constraint: nova.keypair
+  secgroup_base:
+    type: string
+    description: Security group base
+    constraints:
+      - custom_constraint: neutron.security_group
+  secgroup_master:
+    type: string
+    description: Security group for master
+    constraints:
+      - custom_constraint: neutron.security_group
+  image:
+    type: string
+    description: test
+    constraints:
+      - custom_constraint: glance.image
+  internal_network:
+    type: string
+    description: Internal network
+    constraints:
+      - custom_constraint: neutron.network
+  internal_subnet:
+    type: string
+    description: internal subnet
+    constraints:
+      - custom_constraint: neutron.subnet
+  root_password:
+    type: string
+    description: root password
+
+resources:
+  master_server:
+    type: OS::Nova::Server
+    properties:
+      name: { get_param: master_name }
+      image: { get_param: image }
+      key_name: { get_param: keypair }
+      flavor: { get_param: master_flavor }
+      networks:
+        - network: { get_param: internal_network }
+      security_groups:
+        - { get_param: secgroup_base }
+        - { get_param: secgroup_master }
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          template: |
+            #cloud-config
+
+            disable_root: False
+            ssh_deletekeys: False
+            ssh_pwauth: True
+
+            chpasswd:
+              list: |
+                root:$root_password
+              expire: False
+            suse_caasp:
+              role: cluster
+              admin_node: $admin_node
+
+            ntp:
+              enabled: true
+              #servers:
+              #  - ntp1.example.com
+              #  - ntp2.example.com
+              #  - ntp3.example.com
+            runcmd:
+              - /usr/bin/systemctl enable ntpd
+              - /usr/bin/systemctl start ntpd
+          params:
+            $admin_node: { get_param: admin_node_ip }
+            $root_password: { get_param: root_password }
+
+  master_pool_member_1:
+    type: OS::Neutron::LBaaS::PoolMember
+    properties:
+      address: { get_attr: [ master_server, first_address ]}
+      subnet: { get_param: internal_subnet }
+      pool: { get_param: master_lb_pool_1 }
+      protocol_port: { get_param: master_port_1 }
+
+  master_pool_member_2:
+    type: OS::Neutron::LBaaS::PoolMember
+    properties:
+      address: { get_attr: [ master_server, first_address ]}
+      subnet: { get_param: internal_subnet }
+      pool: { get_param: master_lb_pool_2 }
+      protocol_port: { get_param: master_port_2 }

--- a/caasp-multi-master-environment.yaml
+++ b/caasp-multi-master-environment.yaml
@@ -1,0 +1,19 @@
+---
+parameters:
+  root_password: linux
+  admin_flavor: m1.large
+  master_flavor: m1.large
+  worker_flavor: m1.large
+  worker_count: 2
+  master_count: 3
+  external_net: ext-net
+  # Use this lbaas provider for master api:
+  # octavia OR haproxy
+  master_lb_provider: haproxy
+  # Make sure you use a CIDR that doesn't conflict with the CaaSP IPs:
+  # https://github.com/kubic-project/salt/blob/master/pillar/params.sls#L51
+  # https://github.com/kubic-project/velum/blob/master/app/controllers/setup_controller.rb#L34
+  # If dns_nameserver is the same as CaaSPs dns_cluster_ip then the kube service
+  # hostnames won't be resolved.
+  internal_net_cidr: 172.28.0.0/24
+  dns_nameserver: 172.28.0.2

--- a/caasp-multi-master-stack.yaml
+++ b/caasp-multi-master-stack.yaml
@@ -1,0 +1,426 @@
+heat_template_version: 2016-10-14
+
+description: Template to create a CaaSP cluster on OpenStack
+
+parameter_groups:
+  - label: general
+    description: General Parameters
+    parameters:
+      - image
+      - root_password
+
+  - label: sizing
+    description: Sizing Parameters
+    parameters:
+      - admin_flavor
+      - master_flavor
+      - worker_flavor
+      - worker_count
+      - master_count
+
+  - label: network
+    description: Network Parameters
+    parameters:
+      - external_net
+      - internal_net_cidr
+      - dns_nameserver
+      - master_lb_port_1
+      - master_port_1
+      - master_lb_port_2
+      - master_port_2
+      - master_lb_provider
+
+parameters:
+  image:
+    type: string
+    description: Name of image to use for servers
+    constraints:
+      - custom_constraint: glance.image
+  external_net:
+    type: string
+    description: >
+      Name or ID of public network for which floating IP addresses will be allocated
+    default: floating
+  internal_net_cidr:
+    type: string
+    description: Private network range which servers get deployed. Make sure this doesn't conflict with the any IP addresses CaaSP uses (e.g. the dns_cluster_ip).
+    default: 172.28.0.0/24
+  dns_nameserver:
+    type: string
+    description: Address of a dns nameserver reachable.
+    default: 172.28.0.2
+  admin_flavor:
+    type: string
+    description: Admin Flavor
+    default: m1.large
+    constraints:
+      - custom_constraint: nova.flavor
+  master_flavor:
+    type: string
+    description: Master Flavor
+    default: m1.large
+    constraints:
+      - custom_constraint: nova.flavor
+  worker_flavor:
+    type: string
+    description: Worker Flavor
+    default: m1.large
+    constraints:
+      - custom_constraint: nova.flavor
+  worker_count:
+    type: number
+    description: Number of Worker nodes to boot
+    default: 5
+  master_count:
+    type: number
+    description: Number of Master nodes to boot
+    default: 3
+  master_lb_port_1:
+    type: number
+    description: External load balancer port for master api
+    default: 6443
+  master_port_1:
+    type: number
+    description: Master api port
+    default: 6443
+  master_lb_port_2:
+    type: number
+    description: External load balancer port for master api
+    default: 32000
+  master_port_2:
+    type: number
+    description: Master api port
+    default: 32000
+  master_lb_provider:
+    type: string
+    description: Master api load balancer provider, haproxy or octavia
+    default: haproxy
+    constraints:
+      - allowed_values:
+          - haproxy
+          - octavia
+  root_password:
+    type: string
+    description: Root Password for the VMs
+    default: linux
+
+resources:
+  keypair:
+    type: OS::Nova::KeyPair
+    properties:
+      name:
+        str_replace:
+          template: {list_join: ['-', [{get_param: 'OS::stack_name'}, 'caasp-keypair']]}
+          params:
+            ".": "-"
+
+  internal_network:
+    type: OS::Neutron::Net
+    properties:
+      name:
+        str_replace:
+          template: {list_join: ['-', [{get_param: 'OS::stack_name'}, 'caasp-int-net']]}
+          params:
+            ".": "-"
+
+  internal_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      cidr: {get_param: internal_net_cidr}
+      network: {get_resource: internal_network}
+      dns_nameservers:
+        - {get_param: dns_nameserver}
+
+  external_router:
+    type: OS::Neutron::Router
+    properties:
+      external_gateway_info:
+        network: {get_param: external_net}
+
+  external_router_int:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: {get_resource: external_router}
+      subnet: {get_resource: internal_subnet}
+
+  secgroup_base:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+        - protocol: icmp
+        - protocol: tcp
+          port_range_min: 22
+          port_range_max: 22
+        - protocol: tcp
+          port_range_min: 2379
+          port_range_max: 2379
+        - protocol: udp
+          port_range_min: 8472
+          port_range_max: 8472
+
+  secgroup_admin:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+        - protocol: tcp
+          port_range_min: 80
+          port_range_max: 80
+        - protocol: tcp
+          port_range_min: 443
+          port_range_max: 443
+        - protocol: tcp
+          port_range_min: 4505
+          port_range_max: 4506
+        - protocol: tcp
+          port_range_min: 389
+          port_range_max: 389
+
+  secgroup_master:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+        - protocol: tcp
+          port_range_min: 2380
+          port_range_max: 2380
+        - protocol: tcp
+          port_range_min: 6443
+          port_range_max: 6444
+        - protocol: udp
+          port_range_min: 8285
+          port_range_max: 8285
+        - protocol: tcp
+          port_range_min: 30000
+          port_range_max: 32768
+        - protocol: udp
+          port_range_min: 30000
+          port_range_max: 32768
+
+  secgroup_worker:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+        - protocol: tcp
+          port_range_min: 80
+          port_range_max: 80
+        - protocol: tcp
+          port_range_min: 443
+          port_range_max: 443
+        - protocol: tcp
+          port_range_min: 8080
+          port_range_max: 8080
+        - protocol: tcp
+          port_range_min: 8081
+          port_range_max: 8081
+        - protocol: tcp
+          port_range_min: 2380
+          port_range_max: 2380
+        - protocol: tcp
+          port_range_min: 10250
+          port_range_max: 10250
+        - protocol: udp
+          port_range_min: 8285
+          port_range_max: 8285
+        - protocol: tcp
+          port_range_min: 30000
+          port_range_max: 32768
+        - protocol: udp
+          port_range_min: 30000
+          port_range_max: 32768
+
+  admin:
+    type: OS::Nova::Server
+    depends_on:
+      - external_router_int
+    properties:
+      name: { list_join: ['-', [{get_param: 'OS::stack_name'}, 'admin']] }
+      image: { get_param: image }
+      key_name: { get_resource: keypair }
+      flavor: { get_param: admin_flavor }
+      networks:
+        - port: { get_resource: admin_port }
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          template: |
+            #cloud-config
+
+            disable_root: False
+            ssh_deletekeys: False
+            ssh_pwauth: True
+
+            chpasswd:
+              list: |
+                root:$root_password
+              expire: False
+
+            suse_caasp:
+              role: admin
+
+            ntp:
+              enabled: true
+              #servers:
+              #  - ntp1.example.com
+              #  - ntp2.example.com
+              #  - ntp3.example.com
+            runcmd:
+              - /usr/bin/systemctl enable ntpd
+              - /usr/bin/systemctl start ntpd
+          params:
+            $root_password: { get_param: root_password }
+
+  admin_port:
+    type: OS::Neutron::Port
+    depends_on:
+      - external_router_int
+    properties:
+      network: { get_resource: internal_network }
+      security_groups:
+        - { get_resource: secgroup_base }
+        - { get_resource: secgroup_admin }
+
+  admin_floating_ip:
+    type: OS::Neutron::FloatingIP
+    depends_on:
+      - external_router_int
+    properties:
+      floating_network: { get_param: external_net }
+
+  admin_floating_ip_association:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: admin_floating_ip }
+      port_id: { get_resource: admin_port }
+
+  master_resource_group:
+    type: OS::Heat::ResourceGroup
+    depends_on:
+      - external_router_int
+      - master_lb_pool_1
+      - master_lb_pool_2
+    properties:
+      count: { get_param: master_count }
+      resource_def:
+        type: caasp-master.yaml
+        properties:
+          master_name: { list_join: ['-', [{get_param: 'OS::stack_name'}, 'master', '%index%']] }
+          master_flavor: { get_param: master_flavor }
+          master_port_1: { get_param: master_port_1 }
+          master_lb_pool_1: { get_resource: master_lb_pool_1  }
+          master_port_2: { get_param: master_port_2 }
+          master_lb_pool_2: { get_resource: master_lb_pool_2  }
+          admin_node_ip: { get_attr: [admin, first_address] }
+          image: { get_param: image }
+          keypair: { get_resource: keypair }
+          secgroup_base: { get_resource: secgroup_base }
+          secgroup_master: { get_resource: secgroup_master }
+          internal_network: { get_resource: internal_network  }
+          internal_subnet: { get_resource: internal_subnet }
+          root_password: { get_param: root_password }
+
+
+  master_lb:
+    type: OS::Neutron::LBaaS::LoadBalancer
+    depends_on:
+      - external_router_int
+    properties:
+      provider: { get_param: master_lb_provider }
+      vip_subnet: { get_resource: internal_subnet }
+
+  master_lb_listener_1:
+    type: OS::Neutron::LBaaS::Listener
+    depends_on:
+      - external_router_int
+      - master_lb
+    properties:
+      loadbalancer: { get_resource: master_lb }
+      protocol: HTTP
+      protocol_port: { get_param: master_lb_port_1 }
+
+  master_lb_pool_1:
+    type: OS::Neutron::LBaaS::Pool
+    depends_on:
+      - external_router_int
+      - master_lb_listener_1
+    properties:
+      lb_algorithm: ROUND_ROBIN
+      protocol: HTTP
+      listener: { get_resource: master_lb_listener_1 }
+
+  master_lb_listener_2:
+    type: OS::Neutron::LBaaS::Listener
+    depends_on:
+      - external_router_int
+      - master_lb
+    properties:
+      loadbalancer: { get_resource: master_lb }
+      protocol: HTTP
+      protocol_port: { get_param: master_lb_port_2 }
+
+  master_lb_pool_2:
+    type: OS::Neutron::LBaaS::Pool
+    depends_on:
+      - external_router_int
+      - master_lb_listener_2
+    properties:
+      lb_algorithm: ROUND_ROBIN
+      protocol: HTTP
+      listener: { get_resource: master_lb_listener_2 }
+
+  master_lb_floating_ip:
+    depends_on:
+      - external_router_int
+      - master_lb
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_net }
+      port_id: { get_attr: [master_lb, vip_port_id ]}
+
+  worker:
+    type: OS::Heat::ResourceGroup
+    depends_on:
+      - external_router_int
+    properties:
+      count: { get_param: worker_count }
+      resource_def:
+        type: OS::Nova::Server
+        properties:
+          name: { list_join: ['-', [{get_param: 'OS::stack_name'}, 'worker', '%index%']] }
+          image: { get_param: image }
+          key_name: { get_resource: keypair }
+          flavor: { get_param: worker_flavor }
+          networks:
+            - network: { get_resource: internal_network }
+          security_groups:
+            - { get_resource: secgroup_base }
+            - { get_resource: secgroup_worker }
+          user_data_format: RAW
+          user_data:
+            str_replace:
+              template: |
+                #cloud-config
+
+                disable_root: False
+                ssh_deletekeys: False
+                ssh_pwauth: True
+
+                chpasswd:
+                  list: |
+                    root:$root_password
+                  expire: False
+
+                suse_caasp:
+                  role: cluster
+                  admin_node: $admin_node
+
+                ntp:
+                  enabled: true
+                  #servers:
+                  #  - ntp1.example.com
+                  #  - ntp2.example.com
+                  #  - ntp3.example.com
+                runcmd:
+                  - /usr/bin/systemctl enable ntpd
+                  - /usr/bin/systemctl start ntpd
+              params:
+                $admin_node: { get_attr: [admin, first_address] }
+                $root_password: { get_param: root_password }


### PR DESCRIPTION
- Created new env and template caasp-multi-master-environment.yaml
  and caasp-multi-master-stack.yaml for multi master deployment.
- Moved creation of master nova resource and addition to load balancer pool
  to new file caasp_master.yaml This was the only way to possible to create
  master and add it to load balancer pool using nested template.
  Downside to this approach is that its not possible to spin up a
  Multi Master CaaSP cluster via Horizon UI, since Horizon cannot work with
  nested templates unless the nested heat template i.e. caasp-master.yml
  is accessible via http.
- Creates a LBaaS V2 Load balancer, with choice between
  'haproxy' and 'octavia'. 'haproxy' is the default.
- Creates Listener, Pool for ports 32000 and 6443 (bsc#1107999)
- Moved CaaSP master to Resource Group.
- Added parameter 'master_count' to create multiple masters
- Moved the floating ip assignment from master to the loadbalancer (bsc#1108000)
- Added doc link on how to setup prerequisites for Octavia Load balancer
  in README.md