### PR TITLE
Patching node before bootstrapping

### DIFF
--- a/caasp-multi-master-stack.yaml
+++ b/caasp-multi-master-stack.yaml
@@ -507,3 +507,7 @@ resources:
               params:
                 $admin_node: { get_attr: [admin, first_address] }
                 $root_password: { get_param: root_password }
+                
+                runcmd:
+                  - transactional-update up
+                  - reboot


### PR DESCRIPTION
As already mentioned on  https://bugzilla.suse.com/show_bug.cgi?id=1111361, the cpi parameters on heat template won't work if you don't patch the system before the bootstrap happens. without the patching, the velum container on admin gets stuck with:

 Database ready
    Importing seeds from 10-cloud-framework.yaml
    Importing seed: cloud:framework
    OpenStack Cloud Provider config file doesn't exist

Please add that to the template. It might also be a good idea to add warning messages on the readme warning customers that a reboot will happen after running the heat template.